### PR TITLE
fix: build error caused by codegen's lack of support for nested lists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION    := HEAD
 # VERSION as GIT_BRANCH must be different
 ifneq ($(VERSION),$(GIT_BRANCH))
 
-SWAGGER    := https://raw.githubusercontent.com/mac9416/argo/fix-parallelsteps-swagger/api/openapi-spec/swagger.json
+SWAGGER    := https://raw.githubusercontent.com/$(GIT_ORG)/argo/$(VERSION)/api/openapi-spec/swagger.json
 
 clients: java
 


### PR DESCRIPTION
After https://github.com/argoproj/argo/pull/2459 is merged, `make java` will break. That's because codegen apparently doesn't support nested lists for Java. This hack makes the build work again, though it's a bit fragile. Hopefully there won't be any more nested lists soon.

After this is merged, a PR can be opened to fix https://github.com/argoproj-labs/argo-client-java/issues/1.